### PR TITLE
add_by_email() --> Strip "Fwd: " from subject lines

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -445,7 +445,7 @@ def add_by_email():
 
             if subject:
                 # Strip "Fwd: " from subject lines
-                stripped_subject = re.sub("Fwd: ", "", subject)
+                stripped_subject = re.sub("Fwd: ", "", subject, flags=re.IGNORECASE))
                 title = stripped_subject
                 
             else:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -444,7 +444,10 @@ def add_by_email():
                 content = text
 
             if subject:
-                title = subject
+                # Strip "Fwd: " from subject lines
+                stripped_subject = re.sub("Fwd: ", "", subject)
+                title = stripped_subject
+                
             else:
                 title = 'untitled'            
 


### PR DESCRIPTION
- Removed "Fwd: " from subject lines. This means adding articles as fwded emails will look cleaner. 
- Optional next steps: 
--- Modify re function to account for all different types of "FWD/fwd/Fwd"
--- Modify re function to account for "Re:" (and variations)
--- Process data above the email metadata as a custom note. (I.e., if someone fwds/replies to add to Lurnby, keep the reply/fwd text above the metadata as a note, external to the article.